### PR TITLE
update node to LTS version 8.11.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   wait:
     # just use same image as another container, no extra download
-    image: node:8.1.2
+    image: node:8.11.1
     command: >
       sh -c "
 
@@ -25,7 +25,7 @@ services:
     - ./docker/wait/wait-for-it:/usr/local/bin/wait-for-it
 
   frontend:
-    image: node:8.1.2
+    image: node:8.11.1
     command: >
       sh -c "
       yarn &&
@@ -110,7 +110,7 @@ services:
       POSTGRES_DB: db
 
   mjml:
-    image: node:8.1.2
+    image: node:8.11.1
     working_dir: /app/mjml
     command: sh -c 'yarn && ./convert --watch'
     ports:


### PR DESCRIPTION
- quasar 0.15.8 needs node version >= 8.9.0
  see error message when running docker-compose up:
  quasar-framework@0.15.8: The engine "node" is incompatible with this module. Expected version ">= 8.9.0".

- also update the other images to 8.11.1 for consistency